### PR TITLE
Rename Practice to Freestyle

### DIFF
--- a/apprentice-wizard/Game.cpp
+++ b/apprentice-wizard/Game.cpp
@@ -209,13 +209,13 @@ void Game::drawShape(struct Shape s, char ox, char oy){
 void Game::gameDraw(){
   for(byte i = 0; i < MAX_SHAPE; i ++){
     drawShape(shapes[i]);
-    if(!isPractice){
+    if(!isFreestyle){
       drawShape(exampleShapes[i], 64, 0);
     }
   }
-  if(isPractice){
+  if(isFreestyle){
     arduboy.setCursor(64+16,0);
-    arduboy.println(F("PRACTICE"));
+    arduboy.println(F("Freestyle"));
   }
 }
 
@@ -270,7 +270,7 @@ SceneID Game::run(){
     anim = (abs(anim) - 0.1)*(anim/abs(anim));
   }
 
-  if(!isPractice && check()){
+  if(!isFreestyle && check()){
     sound.tone(NOTE_C5, 200, NOTE_C6, 200, NOTE_C7, 400);
     return CLEAR;
   }
@@ -279,7 +279,7 @@ SceneID Game::run(){
     if(arduboy.pressed(B_BUTTON)){
       sound.tone(880, 100, 440, 100, 220, 100);
       clear();
-      if(isPractice){
+      if(isFreestyle){
         return TITLE;
       }
     }else{

--- a/apprentice-wizard/Game.h
+++ b/apprentice-wizard/Game.h
@@ -35,7 +35,7 @@ class Game : public Scene
   bool showCursor = true;
   bool showShapeSelector = false;
   byte shapeSelectorTimer = 0;
-  bool isPractice = false;
+  bool isFreestyle = false;
   bool isJP = false;
   unsigned int timer = 0;
   bool isTimeAttack = false;

--- a/apprentice-wizard/Title.cpp
+++ b/apprentice-wizard/Title.cpp
@@ -16,7 +16,7 @@ SceneID Title::run(){
     switch(cursor){
       case 0:
         game->loadExample(game->stage);
-        game->isPractice = false;
+        game->isFreestyle = false;
         game->isTimeAttack = false;
         game->mode = CIRCLE;
         sound.tone(880, 100);
@@ -24,14 +24,14 @@ SceneID Title::run(){
         break;
       case 1:
         game->loadExample(game->stage);
-        game->isPractice = false;
+        game->isFreestyle = false;
         game->isTimeAttack = true;
         game->mode = CIRCLE;
         sound.tone(880, 100);
         return GAME;
         break;
       case 2:
-        game->isPractice = true;
+        game->isFreestyle = true;
         game->mode = CIRCLE;
         sound.tone(880, 100);
         return GAME;
@@ -73,7 +73,7 @@ SceneID Title::run(){
 PROGMEM const uint8_t jpTitle[] = { 0xf0, 0x81,0x6c,0x8b,0x46, 0xf1, 0x00, 0xf0, 0x80,0x7d,0x48,0x66,0x4d,0x46};
 PROGMEM const uint8_t jpArcade[] = { 0xf0, 0x97,0xee,0xa6,0xee,0xbe};
 PROGMEM const uint8_t jpTimeAttack[] = { 0xf0, 0xb4,0x99,0xd5,0x97,0xb4,0xb8,0xa4};
-PROGMEM const uint8_t jpPractice[] = { 0xf0, 0x4c,0x4a,0x4d,0x4f, };
+PROGMEM const uint8_t jpFreestyle[] = { 0xf0, 0x4c,0x4a,0x4d,0x4f, };
 PROGMEM const uint8_t jpLanguage[] = { 0xf0, 0x54,0x95,0x56};
 
 void Title::draw(){
@@ -98,7 +98,7 @@ void Title::draw(){
     arduboy.setCursor(8 ,9*3);
     drawText(8, 9*3, jpTimeAttack, sizeof(jpTimeAttack));
     arduboy.setCursor(8 ,9*4);
-    drawText(8, 9*4, jpPractice, sizeof(jpPractice));
+    drawText(8, 9*4, jpFreestyle, sizeof(jpFreestyle));
     arduboy.setCursor(8 ,9*5);
     drawText(8, 9*5, jpLanguage, sizeof(jpLanguage));
     arduboy.setCursor(40, 9*5);
@@ -116,7 +116,7 @@ void Title::draw(){
     arduboy.setCursor(8 ,9*3);
     arduboy.println(F("Time Attack"));
     arduboy.setCursor(8 ,9*4);
-    arduboy.println(F("Sketch"));
+    arduboy.println(F("Freestyle"));
     arduboy.setCursor(8 ,9*5);
     arduboy.print(F("Language: "));
     if(game->isJP){arduboy.println("JP");}else{arduboy.println("EN");}


### PR DESCRIPTION
Originally I suggested ‘Sketch’ for the practice mode. However, I think ‘Freestyle’ is  better for the game (more about magic less about drawing).
- Changed internal references.
- Changed English menu text.